### PR TITLE
rosdistro sync, Fri Jul 21 15:20:35 2017

### DIFF
--- a/recipes-ros-lunar/cl-transforms/cl-transforms_0.2.9.bb
+++ b/recipes-ros-lunar/cl-transforms/cl-transforms_0.2.9.bb
@@ -12,6 +12,6 @@ SRC_URI = "https://github.com/ros-gbp/roslisp_common-release/archive/release/lun
 
 SRC_URI[md5sum] = "0c259fe1ef56172df34ab0d56f43a576"
 SRC_URI[sha256sum] = "18f96f8675d0425480cce46cebe2923f01ed0830da5259543dbcbc969366cdb3"
-S = "${WORKDIR}/${ROS_SP}"
+S = "${WORKDIR}/roslisp_common-release-release-lunar-cl_transforms-0.2.9-0"
 
 inherit catkin

--- a/recipes-ros-lunar/geometry2/tf2-geometry-msgs_0.5.15.bb
+++ b/recipes-ros-lunar/geometry2/tf2-geometry-msgs_0.5.15.bb
@@ -1,8 +1,0 @@
-DESCRIPTION = "tf2_geometry_msgs"
-SECTION = "devel"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
-
-DEPENDS = "actionlib-msgs geometry-msgs tf2-ros tf2 orocos-kdl"
-
-require geometry2.inc

--- a/recipes-ros-lunar/ros/rosbuild_1.11.14.bb
+++ b/recipes-ros-lunar/ros/rosbuild_1.11.14.bb
@@ -1,8 +1,0 @@
-DESCRIPTION = "rosbuild contains scripts for managing the CMake-based build system for ROS."
-SECTION = "devel"
-LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
-
-require ros.inc
-
-ROS_PKG_SUBDIR = "core"


### PR DESCRIPTION
Changes:
========
Lunar Changes:
--------------
* *ackermann_msgs --> 1.0.1*
* *actionlib --> 1.11.9*
* *actionlib_lisp --> 0.2.9*
* *actionlib_msgs --> 1.12.5*
* *actionlib_tutorials --> 0.1.10*
* *amcl --> 1.14.0*
* *angles --> 1.9.11*
* *ar_track_alvar --> 0.7.1*
* *ar_track_alvar_msgs --> 0.7.1*
* *auv_msgs --> 0.0.1*
* *base_local_planner --> 1.14.0*
* *bfl --> 0.7.0*
* *bond --> 1.7.19*
* *bond_core --> 1.7.19*
* *bondcpp --> 1.7.19*
* *bondpy --> 1.7.19*
* *calibration --> 0.10.14*
* *calibration_estimation --> 0.10.14*
* *calibration_launch --> 0.10.14*
* *calibration_msgs --> 0.10.14*
* *calibration_setup_helper --> 0.10.14*
* *camera_calibration --> 1.12.20*
* *camera_calibration_parsers --> 1.11.12*
* *camera_info_manager --> 1.11.12*
* *camera_info_manager_py --> 0.2.3*
* *camera_umd --> 0.2.5*
* *can_msgs --> 0.7.5*
* *canopen_402 --> 0.7.5*
* *canopen_chain_node --> 0.7.5*
* *canopen_master --> 0.7.5*
* *canopen_motor_node --> 0.7.5*
* *capabilities --> 0.2.0*
* *carrot_planner --> 1.14.0*
* *cartesian_msgs --> 0.0.3*
* *catkin --> 0.7.6*
* *cl_tf --> 0.2.9*
* *cl_tf2 --> 0.2.9*
* *cl_transforms --> 0.2.9*
* *cl_transforms_stamped --> 0.2.9*
* *cl_urdf --> 0.2.9*
* *cl_utils --> 0.2.9*
* *class_loader --> 0.3.6*
* *clear_costmap_recovery --> 1.14.0*
* *cmake_modules --> 0.4.1*
* *collada_parser --> 1.12.10-r2*
* *collada_urdf --> 1.12.10-r2*
* *combined_robot_hw --> 0.11.5*
* *combined_robot_hw_tests --> 0.11.5*
* *common_msgs --> 1.12.5*
* *common_tutorials --> 0.1.10*
* *compressed_depth_image_transport --> 1.9.5*
* *compressed_image_transport --> 1.9.5*
* *control_msgs --> 1.4.0-r1*
* *control_toolbox --> 1.15.0*
* *controller_interface --> 0.11.5*
* *controller_manager --> 0.11.5*
* *controller_manager_msgs --> 0.11.5*
* *controller_manager_tests --> 0.11.5*
* *convex_decomposition --> 0.1.11*
* *costmap_2d --> 1.14.0*
* *cpp_common --> 0.6.4*
* *cv_bridge --> 1.12.4*
* *cv_camera --> 0.2.1*
* *depth_image_proc --> 1.12.20*
* *desktop --> 1.3.1*
* *desktop_full --> 1.3.1*
* *diagnostic_aggregator --> 1.9.2*
* *diagnostic_analysis --> 1.9.2*
* *diagnostic_common_diagnostics --> 1.9.2*
* *diagnostic_msgs --> 1.12.5*
* *diagnostic_updater --> 1.9.2*
* *diagnostics --> 1.9.2*
* *diff_drive_controller --> 0.12.3*
* *dwa_local_planner --> 1.14.0*
* *dynamic_edt_3d --> 1.9.0*
* *dynamic_reconfigure --> 1.5.48*
* *ecto --> 0.6.12*
* *effort_controllers --> 0.12.3*
* *eigen_conversions --> 1.11.9*
* *eigen_stl_containers --> 0.1.8*
* *executive_smach --> 2.0.1*
* *executive_smach_visualization --> 2.0.1*
* *fake_localization --> 1.14.0*
* *filters --> 1.8.1*
* *force_torque_sensor_controller --> 0.12.3*
* *forward_command_controller --> 0.12.3*
* *gazebo_dev --> 2.7.2*
* *gazebo_msgs --> 2.7.2*
* *gazebo_plugins --> 2.7.2*
* *gazebo_ros --> 2.7.2*
* *gazebo_ros_control --> 2.7.2*
* *gazebo_ros_pkgs --> 2.7.2*
* *gencpp --> 0.5.5*
* *geneus --> 2.2.6*
* *genlisp --> 0.4.16*
* *genmsg --> 0.5.8*
* *gennodejs --> 2.0.1*
* *genpy --> 0.6.5*
* *geodesy --> 0.5.2*
* *geographic_info --> 0.5.2*
* *geographic_msgs --> 0.5.2*
* *geometric_shapes --> 0.5.2*
* *geometry --> 1.11.9*
* *geometry2 --> 0.5.16*
* *geometry_msgs --> 1.12.5*
* *geometry_tutorials --> 0.2.2*
* *gl_dependency --> 1.1.0*
* *global_planner --> 1.14.0*
* *gps_common --> 0.1.9*
* *gps_umd --> 0.1.9*
* *gpsd_client --> 0.1.9*
* *graph_msgs --> 0.1.0*
* *gripper_action_controller --> 0.12.3*
* *gscam --> 1.0.0*
* *hardware_interface --> 0.11.5*
* *image_cb_detector --> 0.10.14*
* *image_common --> 1.11.12*
* *image_geometry --> 1.12.4*
* *image_pipeline --> 1.12.20*
* *image_proc --> 1.12.20*
* *image_publisher --> 1.12.20*
* *image_rotate --> 1.12.20*
* *image_transport --> 1.11.12*
* *image_transport_plugins --> 1.9.5*
* *image_view --> 1.12.20*
* *imu_complementary_filter --> 1.1.5*
* *imu_filter_madgwick --> 1.1.5*
* *imu_sensor_controller --> 0.12.3*
* *imu_tools --> 1.1.5*
* *innok_heros_driver --> 1.0.3*
* *interactive_marker_tutorials --> 0.10.1*
* *interactive_marker_twist_server --> 1.2.0*
* *interactive_markers --> 1.11.3*
* *interval_intersection --> 0.10.14*
* *iot_bridge --> 0.9.0*
* *ivcon --> 0.1.6*
* *joint_limits_interface --> 0.11.5*
* *joint_state_controller --> 0.12.3*
* *joint_state_publisher --> 1.12.11*
* *joint_states_settler --> 0.10.14*
* *joint_trajectory_controller --> 0.12.3*
* *jpeg_streamer --> 0.2.5*
* *jsk_common_msgs --> 4.2.0*
* *jsk_footstep_msgs --> 4.2.0*
* *jsk_gui_msgs --> 4.2.0*
* *jsk_hark_msgs --> 4.2.0*
* *katana --> 1.1.2*
* *katana_arm_gazebo --> 1.1.2*
* *katana_description --> 1.1.2*
* *katana_driver --> 1.1.2*
* *katana_gazebo_plugins --> 1.1.2*
* *katana_moveit_ikfast_plugin --> 1.1.2*
* *katana_msgs --> 1.1.2*
* *katana_teleop --> 1.1.2*
* *katana_tutorials --> 1.1.2*
* *kdl_conversions --> 1.11.9*
* *kdl_parser --> 1.12.10*
* *kdl_parser_py --> 1.12.10*
* *kni --> 1.1.2*
* *laser_assembler --> 1.7.4*
* *laser_cb_detector --> 0.10.14*
* *laser_filters --> 1.8.4-r1*
* *laser_geometry --> 1.6.4*
* *laser_pipeline --> 1.6.2*
* *libfreenect --> 0.5.1*
* *libg2o --> 2017.4.2-r1*
* *libmavconn --> 0.19.0*
* *libphidget21 --> 0.7.3*
* *librviz_tutorial --> 0.10.1*
* *libuvc --> 0.0.5-r3*
* *libuvc_camera --> 0.0.9*
* *libuvc_ros --> 0.0.9*
* *map_msgs --> 1.13.0*
* *map_server --> 1.14.0*
* *marti_can_msgs --> 0.0.9*
* *marti_common_msgs --> 0.0.9*
* *marti_data_structures --> 0.3.0*
* *marti_nav_msgs --> 0.0.9*
* *marti_perception_msgs --> 0.0.9*
* *marti_sensor_msgs --> 0.0.9*
* *marti_visualization_msgs --> 0.0.9*
* *mavlink --> 2017.7.7*
* *mavros --> 0.19.0*
* *mavros_extras --> 0.19.0*
* *mavros_msgs --> 0.19.0*
* *media_export --> 0.2.0*
* *message_filters --> 1.13.0*
* *message_generation --> 0.4.0*
* *message_runtime --> 0.4.12*
* *mk --> 1.14.0*
* *monocam_settler --> 0.10.14*
* *move_base --> 1.14.0*
* *move_base_msgs --> 1.13.0*
* *move_slow_and_clear --> 1.14.0*
* *moveit --> 0.9.8*
* *moveit_commander --> 0.9.8*
* *moveit_controller_manager_example --> 0.9.8*
* *moveit_core --> 0.9.8*
* *moveit_fake_controller_manager --> 0.9.8*
* *moveit_kinematics --> 0.9.8*
* *moveit_msgs --> 0.9.1*
* *moveit_planners --> 0.9.8*
* *moveit_planners_ompl --> 0.9.8*
* *moveit_plugins --> 0.9.8*
* *moveit_resources --> 0.6.2*
* *moveit_ros --> 0.9.8*
* *moveit_ros_benchmarks --> 0.9.8*
* *moveit_ros_control_interface --> 0.9.8*
* *moveit_ros_manipulation --> 0.9.8*
* *moveit_ros_move_group --> 0.9.8*
* *moveit_ros_perception --> 0.9.8*
* *moveit_ros_planning --> 0.9.8*
* *moveit_ros_planning_interface --> 0.9.8*
* *moveit_ros_robot_interaction --> 0.9.8*
* *moveit_ros_visualization --> 0.9.8*
* *moveit_ros_warehouse --> 0.9.8*
* *moveit_runtime --> 0.9.8*
* *moveit_setup_assistant --> 0.9.8*
* *moveit_sim_controller --> 0.1.0*
* *moveit_simple_controller_manager --> 0.9.8*
* *moveit_visual_tools --> 3.3.0*
* *nav_core --> 1.14.0*
* *nav_msgs --> 1.12.5*
* *navfn --> 1.14.0*
* *navigation --> 1.14.0*
* *nerian_sp1 --> 1.6.2-r1*
* *nodelet --> 1.9.10*
* *nodelet_core --> 1.9.10*
* *nodelet_topic_tools --> 1.9.10*
* *nodelet_tutorial_math --> 0.1.10*
* *ntpd_driver --> 1.2.0*
* *object_recognition_msgs --> 0.4.1*
* *octomap --> 1.9.0*
* *octomap_msgs --> 0.3.3*
* *octomap_ros --> 0.4.0-r1*
* *octovis --> 1.9.0*
* *ompl --> 1.3.1-r3*
* *opencv3 --> 3.2.0-r6*
* *openni_camera --> 1.9.5*
* *openni_launch --> 1.9.8*
* *orocos_kdl --> 1.3.1*
* *orocos_kinematics_dynamics --> 1.3.1*
* *p2os_doc --> 2.0.7*
* *p2os_driver --> 2.0.7*
* *p2os_launch --> 2.0.7*
* *p2os_msgs --> 2.0.7*
* *p2os_teleop --> 2.0.7*
* *p2os_urdf --> 2.0.7*
* *pcl_conversions --> 0.2.1*
* *pcl_msgs --> 0.2.0*
* *pcl_ros --> 1.5.3*
* *perception --> 1.3.1*
* *perception_pcl --> 1.5.3*
* *phidgets_api --> 0.7.3*
* *phidgets_drivers --> 0.7.3*
* *phidgets_imu --> 0.7.3*
* *pid --> 0.0.22*
* *plotjuggler --> 1.1.3*
* *pluginlib --> 1.10.5*
* *pluginlib_tutorials --> 0.1.10*
* *pointcloud_to_laserscan --> 1.3.1*
* *polled_camera --> 1.11.12*
* *posedetection_msgs --> 4.2.0*
* *position_controllers --> 0.12.3*
* *pr2_common --> 1.12.0*
* *pr2_dashboard_aggregator --> 1.12.0*
* *pr2_description --> 1.12.0*
* *pr2_machine --> 1.12.0*
* *pr2_msgs --> 1.12.0*
* *python_orocos_kdl --> 1.3.1*
* *python_qt_binding --> 0.3.2-r2*
* *qt_dotgraph --> 0.3.4-r2*
* *qt_gui --> 0.3.4-r2*
* *qt_gui_app --> 0.3.4-r2*
* *qt_gui_core --> 0.3.4-r2*
* *qt_gui_cpp --> 0.3.4-r2*
* *qt_gui_py_common --> 0.3.4-r2*
* *qwt_dependency --> 1.1.0*
* *random_numbers --> 0.3.1-r1*
* *realtime_tools --> 1.10.0*
* *resource_retriever --> 1.12.3*
* *rgbd_launch --> 2.2.2*
* *robot --> 1.3.1*
* *robot_localization --> 2.4.0-r1*
* *robot_model --> 1.12.11*
* *robot_pose_ekf --> 1.14.0*
* *robot_state_publisher --> 1.13.5*
* *ros --> 1.14.0*
* *ros_base --> 1.3.1*
* *ros_canopen --> 0.7.5*
* *ros_comm --> 1.13.0*
* *ros_control --> 0.11.5*
* *ros_control_boilerplate --> 0.4.1*
* *ros_controllers --> 0.12.3*
* *ros_core --> 1.3.1*
* *ros_emacs_utils --> 0.4.11*
* *ros_tutorials --> 0.8.0*
* *ros_type_introspection --> 0.6.3*
* *rosauth --> 0.1.7-r2*
* *rosbag --> 1.13.0*
* *rosbag_migration_rule --> 1.0.0*
* *rosbag_storage --> 1.13.0*
* *rosbash --> 1.14.0*
* *rosboost_cfg --> 1.14.0*
* *rosbuild --> 1.14.0*
* *rosclean --> 1.14.0*
* *rosconsole --> 1.13.0*
* *rosconsole_bridge --> 0.4.4*
* *roscpp --> 1.13.0*
* *roscpp_core --> 0.6.4*
* *roscpp_serialization --> 0.6.4*
* *roscpp_traits --> 0.6.4*
* *roscpp_tutorials --> 0.8.0*
* *roscreate --> 1.14.0*
* *rosdiagnostic --> 1.9.2*
* *rosdoc_lite --> 0.2.7*
* *rosemacs --> 0.4.11*
* *rosgraph --> 1.13.0*
* *rosgraph_msgs --> 1.11.2*
* *roslang --> 1.14.0*
* *roslaunch --> 1.13.0*
* *roslib --> 1.14.0*
* *roslint --> 0.11.1*
* *roslisp --> 1.9.21*
* *roslisp_common --> 0.2.9*
* *roslisp_repl --> 0.4.11*
* *roslisp_utilities --> 0.2.9*
* *roslz4 --> 1.13.0*
* *rosmake --> 1.14.0*
* *rosmaster --> 1.13.0*
* *rosmsg --> 1.13.0*
* *rosnode --> 1.13.0*
* *rosout --> 1.13.0*
* *rospack --> 2.4.1*
* *rosparam --> 1.13.0*
* *rosparam_shortcuts --> 0.2.1*
* *rospy --> 1.13.0*
* *rospy_tutorials --> 0.8.0*
* *rosservice --> 1.13.0*
* *rostest --> 1.13.0*
* *rostime --> 0.6.4*
* *rostopic --> 1.13.0*
* *rosunit --> 1.14.0*
* *roswtf --> 1.13.0*
* *rotate_recovery --> 1.14.0*
* *rqt --> 0.5.0*
* *rqt_action --> 0.4.9*
* *rqt_bag --> 0.4.8*
* *rqt_bag_plugins --> 0.4.8*
* *rqt_common_plugins --> 0.4.8*
* *rqt_console --> 0.4.8*
* *rqt_controller_manager --> 0.11.5*
* *rqt_dep --> 0.4.8*
* *rqt_ez_publisher --> 0.4.0*
* *rqt_graph --> 0.4.8*
* *rqt_gui --> 0.5.0*
* *rqt_gui_cpp --> 0.5.0*
* *rqt_gui_py --> 0.5.0*
* *rqt_image_view --> 0.4.8*
* *rqt_joint_trajectory_controller --> 0.12.3*
* *rqt_launch --> 0.4.8*
* *rqt_logger_level --> 0.4.8*
* *rqt_moveit --> 0.5.7*
* *rqt_msg --> 0.4.8*
* *rqt_nav_view --> 0.5.7*
* *rqt_plot --> 0.4.8*
* *rqt_pose_view --> 0.5.7*
* *rqt_publisher --> 0.4.8*
* *rqt_py_common --> 0.5.0*
* *rqt_py_console --> 0.4.8*
* *rqt_reconfigure --> 0.4.8*
* *rqt_robot_dashboard --> 0.5.7*
* *rqt_robot_monitor --> 0.5.7*
* *rqt_robot_plugins --> 0.5.7*
* *rqt_robot_steering --> 0.5.7*
* *rqt_runtime_monitor --> 0.5.7*
* *rqt_rviz --> 0.5.8*
* *rqt_service_caller --> 0.4.8*
* *rqt_shell --> 0.4.8*
* *rqt_srv --> 0.4.8*
* *rqt_tf_tree --> 0.5.7*
* *rqt_top --> 0.4.8*
* *rqt_topic --> 0.4.8*
* *rqt_web --> 0.4.8*
* *rviz --> 1.12.10*
* *rviz_imu_plugin --> 1.1.5*
* *rviz_plugin_tutorials --> 0.10.1*
* *rviz_python_tutorial --> 0.10.1*
* *rviz_visual_tools --> 3.4.1*
* *self_test --> 1.9.2*
* *sensor_msgs --> 1.12.5*
* *settlerlib --> 0.10.14*
* *shape_msgs --> 1.12.5*
* *sick_tim --> 0.0.10*
* *simulators --> 1.3.1*
* *slime_ros --> 0.4.11*
* *slime_wrapper --> 0.4.11*
* *smach --> 2.0.1*
* *smach_msgs --> 2.0.1*
* *smach_ros --> 2.0.1*
* *smach_viewer --> 2.0.1*
* *smclib --> 1.7.19*
* *socketcan_bridge --> 0.7.5*
* *socketcan_interface --> 0.7.5*
* *soem --> 1.3.0*
* *speech_recognition_msgs --> 4.2.0*
* *srdfdom --> 0.4.2*
* *stage --> 4.3.0*
* *stage_ros --> 1.8.0*
* *std_capabilities --> 0.1.0*
* *std_msgs --> 0.5.11*
* *std_srvs --> 1.11.2*
* *stereo_image_proc --> 1.12.20*
* *stereo_msgs --> 1.12.5*
* *swri_console --> 1.0.0*
* *swri_console_util --> 0.3.0*
* *swri_geometry_util --> 0.3.0*
* *swri_image_util --> 0.3.0*
* *swri_math_util --> 0.3.0*
* *swri_nodelet --> 0.3.0*
* *swri_opencv_util --> 0.3.0*
* *swri_prefix_tools --> 0.3.0*
* *swri_roscpp --> 0.3.0*
* *swri_rospy --> 0.3.0*
* *swri_route_util --> 0.3.0*
* *swri_serial_util --> 0.3.0*
* *swri_string_util --> 0.3.0*
* *swri_system_util --> 0.3.0*
* *swri_transform_util --> 0.3.0*
* *swri_yaml_util --> 0.3.0*
* *test_diagnostic_aggregator --> 1.9.2*
* *test_mavros --> 0.19.0*
* *tf --> 1.11.9*
* *tf2 --> 0.5.16*
* *tf2_bullet --> 0.5.16*
* *tf2_eigen --> 0.5.16*
* *tf2_geometry_msgs --> 0.5.16*
* *tf2_kdl --> 0.5.16*
* *tf2_msgs --> 0.5.16*
* *tf2_py --> 0.5.16*
* *tf2_ros --> 0.5.16*
* *tf2_sensor_msgs --> 0.5.16*
* *tf2_tools --> 0.5.16*
* *tf_conversions --> 1.11.9*
* *theora_image_transport --> 1.9.5*
* *topic_tools --> 1.13.0*
* *trajectory_msgs --> 1.12.5*
* *transmission_interface --> 0.11.5*
* *turtle_actionlib --> 0.1.10*
* *turtle_tf --> 0.2.2*
* *turtle_tf2 --> 0.2.2*
* *turtlesim --> 0.8.0*
* *unique_id --> 1.0.6*
* *unique_identifier --> 1.0.6*
* *urdf --> 1.12.11*
* *urdf_geometry_parser --> 0.0.2*
* *urdf_parser_plugin --> 1.12.11*
* *urdf_sim_tutorial --> 0.3.0*
* *urdf_tutorial --> 0.3.0*
* *urdfdom_py --> 0.3.3*
* *usb_cam --> 0.3.6*
* *uuid_msgs --> 1.0.6*
* *uvc_camera --> 0.2.5*
* *velocity_controllers --> 0.12.3*
* *vision_opencv --> 1.12.4*
* *vision_visp --> 0.10.0-r1*
* *visp --> 3.0.1-r2*
* *visp_auto_tracker --> 0.10.0-r1*
* *visp_bridge --> 0.10.0-r1*
* *visp_camera_calibration --> 0.10.0-r1*
* *visp_hand2eye_calibration --> 0.10.0-r1*
* *visp_tracker --> 0.10.0-r1*
* *visualization_marker_tutorials --> 0.10.1*
* *visualization_msgs --> 1.12.5*
* *visualization_tutorials --> 0.10.1*
* *viz --> 1.3.1*
* *voxel_grid --> 1.14.0*
* *warehouse_ros --> 0.9.0*
* *webkit_dependency --> 1.1.0*
* *xacro --> 1.12.0-r1*
* *xmlrpcpp --> 1.13.0*
* *xsens_driver --> 2.1.0*
* *xv_11_laser_driver --> 0.3.0*